### PR TITLE
POC Converting Serverless to Stax

### DIFF
--- a/ops/Gemfile
+++ b/ops/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'stax', '>= 0.1.15'

--- a/ops/Staxfile
+++ b/ops/Staxfile
@@ -1,0 +1,3 @@
+require_relative 'lib/stack'
+
+stack :db

--- a/ops/cf/db.rb
+++ b/ops/cf/db.rb
@@ -1,0 +1,8 @@
+description 'ocpp dynamo'
+
+parameter :app,    type: :String
+parameter :branch, type: :String
+
+include_template(
+  'db/dynamo.rb',
+)

--- a/ops/cf/db/dynamo.rb
+++ b/ops/cf/db/dynamo.rb
@@ -1,0 +1,18 @@
+resource :DynamoDatabase, 'AWS::DynamoDB::Table' do
+  table_name Fn::sub('${app}_${branch}')
+  attribute_definitions [
+    { AttributeName: :connectionId,                   AttributeType: :S }
+  ]
+  key_schema [
+    { AttributeName: :connectionId,                   KeyType: :HASH }
+  ]
+  provisioned_throughput do
+    read_capacity_units 10
+    write_capacity_units 10
+  end
+  # encryption is cool but costs money $$$$
+  # SSE_specification(
+  #   SSEEnabled: true
+  # )
+  tag :Stack, Fn::ref('AWS::StackName')
+end

--- a/ops/lib/stack.rb
+++ b/ops/lib/stack.rb
@@ -1,0 +1,13 @@
+module Stax
+  class Stack < Base
+      ## stacks should only be allowed to create in certain accounts
+    no_commands do
+      def ensure_account!()
+        # TODO: fill me
+        if aws_account_id != 'XXXXXXXXXXXX'
+          fail_task("#{stack_name} should only be created in our account")
+        end
+      end
+    end
+  end
+end

--- a/ops/lib/stack/db.rb
+++ b/ops/lib/stack/db.rb
@@ -1,0 +1,32 @@
+require 'stax/mixin/dynamodb'
+module Stax
+  class Db < Stack
+    include DynamoDB
+
+    PRIMARY_REGION = 'us-west-2'
+
+    no_commands do
+      def cfn_parameters
+        {
+          app: app_name,
+          branch: branch_name,
+        }
+      end
+    end
+
+    desc 'create', 'create stack'
+    def create
+      ensure_account!()
+      super
+    end
+
+    desc 'delete', 'delete stack'
+    def delete
+      if aws_region == PRIMARY_REGION
+        warn('dynamodb table will be retained, please delete if no longer needed')
+        id(:DynamoDatabase)
+      end
+      super
+    end
+  end
+end


### PR DESCRIPTION
## Overview
Converts the Dynamo table defined in `serverless.yaml` over to a [Stax](https://github.com/rlister/stax) compatible version.

## Usage
In the `ops/` directory
1. `bundle install`
2. `bundle exec stax create`

Note: must be logged into correct aws account in terminal